### PR TITLE
This is causing "CURLOPT_FOLLOWLOCATION cannot be activated when in safe...

### DIFF
--- a/FirstData.php
+++ b/FirstData.php
@@ -71,7 +71,7 @@ class FirstData
 	    CURLOPT_FRESH_CONNECT  => 1,
 		CURLOPT_PORT		   => 443,
 	    CURLOPT_USERAGENT      => 'curl-php',
-	    CURLOPT_FOLLOWLOCATION => true,
+	    CURLOPT_FOLLOWLOCATION => false,
 		CURLOPT_RETURNTRANSFER => true,
 		CURLOPT_CUSTOMREQUEST  => 'POST',
 		CURLOPT_HTTPHEADER	   => array('Content-Type: application/json; charset=UTF-8;','Accept: application/json' ),


### PR DESCRIPTION
...safe_mode or an open_basedir is set" on a shared server. Changing to false fixed it, and it still processed the payment.

Wondering if there is any value to having this as true?
