### PR TITLE
Fixing autoload path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "VinceG\\FirstDataApi\\": ""}
+        "psr-0": { "VinceG\\FirstDataApi\\": "VinceG/FirstDataApi/src"}
     },
     "target-dir": "VinceG/FirstDataApi",
     "minimum-stability": "dev"


### PR DESCRIPTION
This commit fixes the autoload path in composer.json so that this library gets loaded properly via namespacing.  To test the current error do the following:

1)  Build a simple composer.json
{
  "require": {
     "vinceg/firstdataapi": "dev-master"
  }
}

2)  run composer update

3)  Build a simple test.php file in same dir as composer.json
<?php
require_once 'vendor/autoload.php';
use VinceG\FirstDataApi\FirstData;
$firstData = new FirstData();

4)  Run the script and you'll get a class not found error

This commit fixes this issue.  Thanks for a wonderful and sorely needed library!
