### PR TITLE
Cast Credit Card to string.

### DIFF
--- a/src/VinceG/FirstDataApi/FirstData.php
+++ b/src/VinceG/FirstDataApi/FirstData.php
@@ -196,7 +196,7 @@ class FirstData
 	 * @return object
 	 */
 	public function setCreditCardNumber($number) {
-		$this->setPostData('cc_number', $number);
+		$this->setPostData('cc_number', (string) $number);
 		return $this;
 	}
 	/**


### PR DESCRIPTION
An issue with the FirstData e4 Payment Gateway, returns an error ('Internal Server Error') - and no code making debugging somewhat obstreperous - should the Credit Card not be explicitly cast to a string.
