### PR TITLE
Additional error handling for cases when exact_resp_code is 00

### DIFF
--- a/src/VinceG/FirstDataApi/FirstData.php
+++ b/src/VinceG/FirstDataApi/FirstData.php
@@ -490,9 +490,20 @@ class FirstData
 				$this->setErrorMessage($returnedMessage);
 			}
 		} else {
-			// We have a json string, empty error message
-			$this->setErrorMessage('');
-			$this->setErrorCode(0);
+			// for cases when exact_resp_code is 00, but bank response code is not successful
+			if ($this->isError()) {
+				$code = $this->getBankResponseCode();
+				$codes = $this->getBankResponseCodes();
+				$error = isset($codes[$code]) ? $codes[$code]['name'] : null;
+				
+				$this->setErrorMessage($error);
+				$this->setErrorCode(42);
+			}
+			else {
+				// We have a json string, empty error message
+				$this->setErrorMessage('');
+				$this->setErrorCode(0);
+			}
 		}
 
 		// close


### PR DESCRIPTION
For cases when exact_resp_code is 00, but the bank response code is not successful, for example:

```
{
    "transaction_error": 0,
    "transaction_approved": 0,
    "exact_resp_code": "00",
    "exact_message": "Transaction Normal",
    "bank_resp_code": "201",
    "bank_message": "Invalid CC Number",
    "sequence_no": "***",
    "retrieval_ref_no": "***",
    "merchant_name": "***",
    "merchant_address": "***",
    "merchant_city": "***",
    "merchant_province": "***",
    "merchant_country": "United States",
    "merchant_postal": "***",
    "merchant_url": "HTTPS://***",
    "ctr": "***",
    "gateway_id": "***",
    "transaction_type": "00",
    "amount": 0.01,
    "transaction_tag": ***,
    "cc_expiry": "***",
    "cardholder_name": "***",
    "cc_verification_str2": "***",
    "cvd_presence_ind": 1,
    "reference_no": "***",
    "client_ip": "192.*****",
    "client_email": "a***@gmail.com",
    "currency_code": "USD",
    "partial_redemption": 0,
    "transarmor_token": "************1111",
    "credit_card_type": "Visa"
}
```