### PR TITLE
Update FirstData.php

### DIFF
--- a/src/VinceG/FirstDataApi/FirstData.php
+++ b/src/VinceG/FirstDataApi/FirstData.php
@@ -241,6 +241,31 @@ class FirstData
 		$this->setPostData('credit_card_type', $type);
 		return $this;
 	}
+	
+	/**
+	 * Setting Track 1 and Track 2 data allows input from USB credit card swiper
+	 * For format of track data see: http://www.gae.ucm.es/~padilla/extrawork/magexam1.html
+	 * /
+	 
+	/**
+	 * set Track1 data
+	 * @param string $track
+	 * @return object
+	 */	
+        public function setTrack1($track) {
+                $this->setPostData('track1', $track);
+                return $this;
+        }	/**
+	 * set Track2 data
+	 * @param string $track
+	 * @return object
+	 */
+        
+        public function setTrack2($track) {
+                $this->setPostData('track2', $track;
+                return $this;
+        }
+	
 	/**
 	 * set credit card holder name
 	 * @param string $name


### PR DESCRIPTION
I added track1 and track2 as options in the post data.  This allowed us to accept input from USB magnetic stripe credit card readers.

We use a USB swiper that has keyboard emulation.  We just capture the text that is read in.  Split the track string by the semi-colon character to split it into track1, track2, and track 3 (First Data only appears to allow for track1 and track2 data though).